### PR TITLE
Add handling for empty GPX files

### DIFF
--- a/gpxtrackposter/track.py
+++ b/gpxtrackposter/track.py
@@ -23,7 +23,7 @@ class Track:
     def load_gpx(self, file_name: str):
         try:
             self.file_names = [os.path.basename(file_name)]
-            # Handle empty gpx files 
+            # Handle empty gpx files
             # (for example, treadmill runs pulled via garmin-connect-export)
             if os.path.getsize(file_name) == 0:
                 raise TrackLoadError("Empty GPX file")

--- a/gpxtrackposter/track.py
+++ b/gpxtrackposter/track.py
@@ -23,6 +23,10 @@ class Track:
     def load_gpx(self, file_name: str):
         try:
             self.file_names = [os.path.basename(file_name)]
+            # Handle empty gpx files 
+            # (for example, treadmill runs pulled via garmin-connect-export)
+            if os.path.getsize(file_name) == 0:
+                raise TrackLoadError("Empty GPX file")
             with open(file_name, 'r') as file:
                 self._load_gpx_data(mod_gpxpy.parse(file))
         except TrackLoadError as e:


### PR DESCRIPTION
I have several empty GPX files due to things like treadmill activities -- this is how they're being pulled down by the garmin-connect-export utility. I'm getting an unpleasant error message coming from gpxpy for each of these files, so I added a check on the file size before calling _load_gpx_data. If the file is empty, it raises a TrackLoadError. 

Error message:

> ERROR:root:no element found: line 1, column 0
Traceback (most recent call last):
  File "/home/joe/Documents/GpxTrackPoster/venv/lib/python3.5/site-packages/gpxpy/parser.py", line 189, in parse
    self.xml_parser = XMLParser(self.xml)
  File "/home/joe/Documents/GpxTrackPoster/venv/lib/python3.5/site-packages/gpxpy/parser.py", line 40, in __init__
    self.dom = mod_minidom.parseString(xml)
  File "/usr/lib/python3.5/xml/dom/minidom.py", line 1968, in parseString
    return expatbuilder.parseString(string)
  File "/usr/lib/python3.5/xml/dom/expatbuilder.py", line 925, in parseString
    return builder.parseString(string)
  File "/usr/lib/python3.5/xml/dom/expatbuilder.py", line 223, in parseString
    parser.Parse(string, True)
xml.parsers.expat.ExpatError: no element found: line 1, column 0

