### PR TITLE
Change logging level to 'error' for a few critical items.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ gpx_dir/*
 output/*
 .env
 .idea
+*.svg

--- a/gpxtrackposter/track_loader.py
+++ b/gpxtrackposter/track_loader.py
@@ -67,7 +67,7 @@ class TrackLoader:
             try:
                 shutil.rmtree(self.cache_dir)
             except OSError as e:
-                log.info("Failed: {}".format(e))
+                log.error("Failed: {}".format(e))
 
     def load_tracks(self, base_dir: str) -> List[Track]:
         """Load tracks base_dir and return as a List of tracks"""
@@ -147,7 +147,7 @@ class TrackLoader:
             try:
                 t = future.result()
             except TrackLoadError as e:
-                log.info("Error while loading {}: {}".format(file_name, e))
+                log.error("Error while loading {}: {}".format(file_name, e))
             else:
                 tracks[file_name] = t
 
@@ -180,7 +180,7 @@ class TrackLoader:
             try:
                 t.store_cache(self._get_cache_file_name(file_name))
             except Exception as e:
-                log.warning('Failed to store track {} to cache: {}'.format(file_name, e))
+                log.error('Failed to store track {} to cache: {}'.format(file_name, e))
             else:
                 log.info('Stored track {} to cache'.format(file_name))
 


### PR DESCRIPTION
I changed the logging level of a few messages from info/warning to error. The three messages I updated (failed removing cache directory, failed loading track from file, failed writing to cache) all seem like things that should go to output regardless of whether verbose mode is turned on, e.g., issue #19. 

Happy to discuss/make additional changes if you think there's a better way to handle it.