### PR TITLE
fix heatmap drawer to respect secondary color

### DIFF
--- a/gpxtrackposter/heatmap_drawer.py
+++ b/gpxtrackposter/heatmap_drawer.py
@@ -105,18 +105,10 @@ class HeatmapDrawer(TracksDrawer):
 
     def draw(self, dr: svgwrite.Drawing, size: XY, offset: XY):
         """Draw the heatmap based on tracks."""
-        normal_lines = []
-        special_lines = []
         bbox = self._determine_bbox()
         for tr in self.poster.tracks:
+            color = self.color(self.poster.length_range, tr.length, tr.special)
             for line in utils.project(bbox, size, offset, tr.polylines):
-                if tr.special:
-                    special_lines.append(line)
-                else:
-                    normal_lines.append(line)
-        for lines, color in [(normal_lines, self.poster.colors['track']),
-                             (special_lines, self.poster.colors['special'])]:
-            for opacity, width in [(0.1, 5.0), (0.2, 2.0), (1.0, 0.3)]:
-                for line in lines:
+                for opacity, width in [(0.1, 5.0), (0.2, 2.0), (1.0, 0.3)]:
                     dr.add(dr.polyline(points=line, stroke=color, stroke_opacity=opacity, fill='none',
                                        stroke_width=width, stroke_linejoin='round', stroke_linecap='round'))


### PR DESCRIPTION
Secondary color is currently ignored for heatmaps. This pr fixes the issue.

Still, in combination with `--heatmap-center` and `--heatmap-radius`, not all tracks are drawn and the secondary color (representing the longest activity) may be not in the visible area.