### PR TITLE
Add github profile-like drawer

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ optional arguments:
   --special FILE        Mark track file from the GPX directory as special; use
                         multiple times to mark multiple tracks.
   --type TYPE           Type of poster to create (default: "grid", available:
-                        "grid", "calendar", "heatmap", "circular").
+                        "grid", "calendar", "heatmap", "circular", "github").
   --background-color COLOR
                         Background color of poster (default: "#222222").
   --track-color COLOR   Color of tracks (default: "#4DD2FF").

--- a/gpxtrackposter/cli.py
+++ b/gpxtrackposter/cli.py
@@ -26,7 +26,7 @@ optional arguments:
   --special FILE        Mark track file from the GPX directory as special; use
                         multiple times to mark multiple tracks.
   --type TYPE           Type of poster to create (default: "grid", available:
-                        "grid", "calendar", "heatmap", "circular").
+                        "grid", "calendar", "heatmap", "circular", "github").
   --background-color COLOR
                         Background color of poster (default: "#222222").
   --track-color COLOR   Color of tracks (default: "#4DD2FF").
@@ -64,9 +64,12 @@ import appdirs
 import logging
 import os
 import sys
+
 from gpxtrackposter import poster, track_loader
-from gpxtrackposter import grid_drawer, calendar_drawer, circular_drawer, heatmap_drawer
+from gpxtrackposter import grid_drawer, circular_drawer, heatmap_drawer
+from gpxtrackposter import github_drawer, calendar_drawer
 from gpxtrackposter.exceptions import ParameterError, PosterError
+
 
 __app_name__ = "create_poster"
 __app_author__ = "flopp.net"
@@ -81,6 +84,7 @@ def main():
         "calendar": calendar_drawer.CalendarDrawer(p),
         "heatmap": heatmap_drawer.HeatmapDrawer(p),
         "circular": circular_drawer.CircularDrawer(p),
+        "github": github_drawer.GithubDrawer(p),
     }
 
     args_parser = argparse.ArgumentParser()
@@ -255,6 +259,8 @@ def main():
     }
     p.units = args.units
     p.set_tracks(tracks)
+    if args.type == "github":
+        p.height = 55 + p.years.count() * 43
     p.draw(drawers[args.type], args.output)
 
 

--- a/gpxtrackposter/cli.py
+++ b/gpxtrackposter/cli.py
@@ -11,6 +11,7 @@ usage: create_poster.py [-h] [--gpx-dir DIR] [--output FILE]
                         [--logfile FILE] [--heatmap-center LAT,LNG]
                         [--heatmap-radius RADIUS_KM] [--circular-rings]
                         [--circular-ring-color COLOR]
+                        [--special_distance DISTANCE][--special_distance2 DISTANCE]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -210,6 +211,22 @@ def main():
         "--verbose", dest="verbose", action="store_true", help="Verbose logging."
     )
     args_parser.add_argument("--logfile", dest="logfile", metavar="FILE", type=str)
+    args_parser.add_argument(
+        "--special-distance",
+        dest="special_distance",
+        metavar="DISTANCE",
+        type=float,
+        default=10.0,
+        help="Special Distance1 by km and color with the special_color",
+    )
+    args_parser.add_argument(
+        "--special-distance2",
+        dest="special_distance2",
+        metavar="DISTANCE",
+        type=float,
+        default=20.0,
+        help="Special Distance2 by km and corlor with the special_color2",
+    )
 
     for _, drawer in drawers.items():
         drawer.create_args(args_parser)
@@ -249,6 +266,12 @@ def main():
     p.set_language(args.language)
     p.athlete = args.athlete
     p.title = args.title
+
+    p.special_distance = {
+        "special_distance": args.special_distance,
+        "special_distance2": args.special_distance2,
+    }
+
     p.colors = {
         "background": args.background_color,
         "track": args.track_color,

--- a/gpxtrackposter/github_drawer.py
+++ b/gpxtrackposter/github_drawer.py
@@ -1,0 +1,113 @@
+import calendar
+import datetime
+import locale
+import svgwrite
+
+from gpxtrackposter import utils
+from gpxtrackposter.exceptions import PosterError
+from poster import Poster
+from gpxtrackposter.tracks_drawer import TracksDrawer
+from gpxtrackposter.xy import XY
+
+
+class GithubDrawer(TracksDrawer):
+    """Draw a gtihub profile-like poster"""
+
+    def __init__(self, the_poster: Poster):
+        super().__init__(the_poster)
+
+    def draw(self, dr: svgwrite.Drawing, size: XY, offset: XY):
+        if self.poster.tracks is None:
+            raise PosterError("No tracks to draw")
+        year_size = 200 * 4.0 / 80.0
+        year_style = f"font-size:{year_size}px; font-family:Arial;"
+        year_length_style = f"font-size:{110 * 3.0 / 80.0}px; font-family:Arial;"
+        month_names_style = f"font-size:2.5px; font-family:Arial"
+        year_num = 0
+        total_length_year_dict = self.poster.total_length_year_dict
+        for year in range(self.poster.years.from_year, self.poster.years.to_year + 1):
+            start_date_weekday, _ = calendar.monthrange(year, 1)
+            github_rect_day = datetime.date(year, 1, 1)
+            github_rect_day += datetime.timedelta(-start_date_weekday)
+            year_length = total_length_year_dict.get(year, 0)
+            year_length = utils.format_float(self.poster.m2u(year_length))
+            month_names = [
+                locale.nl_langinfo(day)[:3]
+                for day in [
+                    locale.MON_1,
+                    locale.MON_2,
+                    locale.MON_3,
+                    locale.MON_4,
+                    locale.MON_5,
+                    locale.MON_6,
+                    locale.MON_7,
+                    locale.MON_8,
+                    locale.MON_9,
+                    locale.MON_10,
+                    locale.MON_11,
+                    locale.MON_12,
+                ]
+            ]
+            km_or_mi = "mi"
+            if self.poster.units == "metric":
+                km_or_mi = "km"
+            dr.add(
+                dr.text(
+                    f"{year}",
+                    insert=offset.tuple(),
+                    fill=self.poster.colors["text"],
+                    alignment_baseline="hanging",
+                    style=year_style,
+                )
+            )
+
+            dr.add(
+                dr.text(
+                    f"{year_length} {km_or_mi}",
+                    insert=(offset.tuple()[0] + 165, offset.tuple()[1] + 2),
+                    fill=self.poster.colors["text"],
+                    alignment_baseline="hanging",
+                    style=year_length_style,
+                )
+            )
+            # add month name up to the rect
+            # beacuse of svg text auto trim the spaces()
+            for num, name in enumerate(month_names):
+                dr.add(
+                    dr.text(
+                        f"{name}",
+                        insert=(offset.tuple()[0] + 15.5 * num, offset.tuple()[1] + 14),
+                        fill=self.poster.colors["text"],
+                        style=month_names_style,
+                    )
+                )
+
+            rect_x = 10
+            # add every day of this year for 53 weeks and per week has 7 days
+            for i in range(53):
+                rect_y = offset.y + year_size + 2
+                for j in range(7):
+                    rect_y += 3.5
+                    color = "#444444"
+                    date_title = str(github_rect_day)
+                    if date_title in self.poster.tracks_by_date:
+                        tracks = self.poster.tracks_by_date[date_title]
+                        length = sum([t.length for t in tracks])
+                        has_special = 10.0 < length / 1000 < 20.0
+                        color = self.color(
+                            self.poster.length_range_by_date, length, has_special
+                        )
+                        if length / 1000 >= 20.0:
+                            color = "red"
+                        str_length = utils.format_float(self.poster.m2u(length))
+                        date_title = f"{date_title} {str_length} {km_or_mi}"
+
+                    rect = dr.rect((rect_x, rect_y), (2.6, 2.6), fill=color)
+                    rect.set_desc(title=date_title)
+                    dr.add(rect)
+                    github_rect_day += datetime.timedelta(1)
+                    if int(github_rect_day.year) > year:
+                        break
+                rect_x += 3.5
+            year_num += 1
+            offset.y += 3.5 * 9 + year_size + 1.5

--- a/gpxtrackposter/github_drawer.py
+++ b/gpxtrackposter/github_drawer.py
@@ -27,7 +27,7 @@ class GithubDrawer(TracksDrawer):
         for year in range(self.poster.years.from_year, self.poster.years.to_year + 1):
             start_date_weekday, _ = calendar.monthrange(year, 1)
             github_rect_first_day = datetime.date(year, 1, 1)
-            # Github profile the first day start from the last Monday fo last year or the first Monday of this year
+            # Github profile the first day start from the last Monday of the last year or the first Monday of this year
             # It depands on if the first day of this year is Monday or not.
             github_rect_day = github_rect_first_day + datetime.timedelta(
                 -start_date_weekday
@@ -73,7 +73,7 @@ class GithubDrawer(TracksDrawer):
                     style=year_length_style,
                 )
             )
-            # add month name up to the poster one by one beacuse of svg text auto trim the spaces.
+            # add month name up to the poster one by one because of svg text auto trim the spaces.
             for num, name in enumerate(month_names):
                 dr.add(
                     dr.text(

--- a/gpxtrackposter/github_drawer.py
+++ b/gpxtrackposter/github_drawer.py
@@ -84,7 +84,7 @@ class GithubDrawer(TracksDrawer):
                     )
                 )
 
-            rect_x = 10
+            rect_x = 10.0
             dom = (2.6, 2.6)
             # add every day of this year for 53 weeks and per week has 7 days
             for i in range(54):
@@ -107,7 +107,7 @@ class GithubDrawer(TracksDrawer):
                         if length / 1000 >= distance2:
                             color = self.poster.colors.get(
                                 "special2"
-                            ) or self.poster.get("special")
+                            ) or self.poster.colors.get("special")
                         str_length = utils.format_float(self.poster.m2u(length))
                         date_title = f"{date_title} {str_length} {km_or_mi}"
 

--- a/gpxtrackposter/poster.py
+++ b/gpxtrackposter/poster.py
@@ -52,6 +52,7 @@ class Poster:
             "special": "#FFFF00",
             "track": "#4DD2FF",
         }
+        self.special_distance = {"special_distance1": "10", "special_distance2": "20"}
         self.width = 200
         self.height = 300
         self.years = None

--- a/gpxtrackposter/poster.py
+++ b/gpxtrackposter/poster.py
@@ -4,6 +4,7 @@
 # Use of this source code is governed by a MIT-style
 # license that can be found in the LICENSE file.
 
+from collections import defaultdict
 import gettext
 import locale
 import svgwrite
@@ -225,12 +226,15 @@ class Poster:
     def __compute_track_statistics(self):
         length_range = ValueRange()
         total_length = 0
+        total_length_year_dict = defaultdict(int)
         weeks = {}
         for t in self.tracks:
             total_length += t.length
+            total_length_year_dict[t.start_time.year] += t.length
             length_range.extend(t.length)
             # time.isocalendar()[1] -> week number
             weeks[(t.start_time.year, t.start_time.isocalendar()[1])] = 1
+        self.total_length_year_dict = total_length_year_dict
         return (
             total_length,
             total_length / len(self.tracks),


### PR DESCRIPTION
Dear Sir,
I added a new type of drawer like github profile which like the picture below, but the same as the calander_drawer I used Monday as the first day of the week (github profile's is Sunday)
![image](https://user-images.githubusercontent.com/15976103/63489053-9a7cc800-c4e3-11e9-809a-a64c0202677b.png)
Also did I add title to every rect when your mouse over it you can see the date and the length like below
![image](https://user-images.githubusercontent.com/15976103/63489446-b896f800-c4e4-11e9-8b3f-3f38a73c88b2.png)
And I added two args (special-distance and special-distance2) which can auto corlor the rect of the github-like profile.
I changed the length of the poster that depends on the years count.
e.g.
![image](https://user-images.githubusercontent.com/15976103/63489391-91402b00-c4e4-11e9-95a8-839956131628.png)
and the poster will be like these
![image](https://user-images.githubusercontent.com/15976103/63489516-ea0fc380-c4e4-11e9-9e15-2c8d3a512c93.png)
![image](https://user-images.githubusercontent.com/15976103/63489749-7de18f80-c4e5-11e9-8326-21b3c6493591.png)
Sincerely hope to get your valuable advice
Thank you.
