### PR TITLE
Add: Nike export gpx change: runtastic repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Create a visually appealing poster from your GPX tracks - heavily inspired by ht
 
 
 ## Usage
-First of all, you need directory with a bunch of GPX files (e.g. you can export all your tracks from Garmin Connect with the excellent tool [garmin-connect-export](https://github.com/kjkjava/garmin-connect-export), or use [StravaExportToGPX](https://github.com/flopp/StravaExportToGPX), or use [runtastic](https://github.com/Metalnem/runtastic) to convert the activities in a Strava or Runtastic export zip file to GPX).
+First of all, you need directory with a bunch of GPX files (e.g. you can export all your tracks from Garmin Connect with the excellent tool [garmin-connect-export](https://github.com/kjkjava/garmin-connect-export), or use [StravaExportToGPX](https://github.com/flopp/StravaExportToGPX), or use [runtastic](https://github.com/yihong0618/Runtastic), or use [nrc-exporter](https://github.com/yasoob/nrc-exporter) to convert the activities in a Strava or Runtastic or `Nike Run Club` export zip file to GPX or GPX files).
 
 You will need a little experience running things from the command line to use this script. That said, here are the usage details from the `--help` flag:
 


### PR DESCRIPTION
Old Runtastic export way is down I worte a new one which is using python. And for now there is one way to export gpx files from `nrc`