### PR TITLE
add: min-distance for filter tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ usage: create_poster [-h] [--gpx-dir DIR] [--output FILE]
                      [--background-color COLOR] [--track-color COLOR]
                      [--track-color2 COLOR] [--text-color COLOR]
                      [--special-color COLOR] [--special-color2 COLOR]
+                     [--min-distance DISTANCE]
                      [--special-distance DISTANCE] [--special-distance2 DISTANCE]
                      [--units UNITS] [--clear-cache] [--verbose]
                      [--logfile FILE] [--heatmap-center LAT,LNG]
@@ -51,6 +52,8 @@ optional arguments:
                         Special track distance (float default: 10.0 for github drawer)
   --special-distance2 Distance
                         Secondary track distance (float default: 20.0 for github drawer)
+  --min-distance Distance
+                        Min distance(km) to filter tracks
 
   --units UNITS         Distance units; "metric", "imperial" (default:
                         "metric").
@@ -143,7 +146,7 @@ We currently support
 ## Setup
 1. Clone the repository: `git clone https://github.com/flopp/GpxTrackPoster.git`
 2. `cd GpxTrackPoster`
-3. Create virtualenv: `virtualenv -p /usr/bin/python3 venv`
+3. Create virtualenv: `virtualenv -p /usr/bin/python3 venv` or `python -m venv venv`
 4. Activate virtualenv: `source venv/bin/activate`
 5. Install the package: `pip install .`
 6. Install development requirements (only if you want to contribute code!): `pip install -r requirements-dev.txt`
@@ -176,4 +179,4 @@ E.g. use [Poedit](https://poedit.net/) or [Localise Online Editor](https://local
 `msgfmt gpxposter.po -o gpxposter.mo`
 
 ## License
-[MIT](https://github.com/flopp/GpxTrackPoster/blob/master/LICENSE) &copy; 2016-2019 Florian Pigorsch
+[MIT](https://github.com/flopp/GpxTrackPoster/blob/master/LICENSE) &copy; 2016-2020 Florian Pigorsch

--- a/gpxtrackposter/cli.py
+++ b/gpxtrackposter/cli.py
@@ -6,6 +6,7 @@ usage: create_poster.py [-h] [--gpx-dir DIR] [--output FILE]
                         [--athlete NAME] [--special FILE] [--type TYPE]
                         [--background-color COLOR] [--track-color COLOR]
                         [--track-color2 COLOR] [--text-color COLOR]
+                        [--min-distance distance]
                         [--special-color COLOR] [--special-color2 COLOR]
                         [--units UNITS] [--clear-cache] [--verbose]
                         [--logfile FILE] [--heatmap-center LAT,LNG]
@@ -33,6 +34,8 @@ optional arguments:
   --track-color COLOR   Color of tracks (default: "#4DD2FF").
   --track-color2 COLOR  Secondary color of tracks (default: none).
   --text-color COLOR    Color of text (default: "#FFFFFF").
+  --min-distance DISTANCE
+                        min distance to filter tracks
   --special-color COLOR
                         Special track color (default: "#FFFF00").
   --special-color2 COLOR
@@ -223,6 +226,14 @@ def main():
         default=20.0,
         help="Special Distance2 by km and corlor with the special_color2",
     )
+    args_parser.add_argument(
+        "--min-distance",
+        dest="min_distance",
+        metavar="DISTANCE",
+        type=float,
+        default=1.0,
+        help="min distance by km for track filter",
+    )
 
     for _, drawer in drawers.items():
         drawer.create_args(args_parser)
@@ -246,6 +257,7 @@ def main():
         raise ParameterError(f"Bad year range: {args.year}.")
 
     loader.special_file_names = args.special
+    loader.min_length = args.min_distance * 1000
     if args.clear_cache:
         print("Clearing cache...")
         loader.clear_cache()


### PR DESCRIPTION
This `pr` add  min-distance for filter tracks with distance,  because I have a lot of tracks I want to generate grid only more the 10km tracks I think that will be easy.
Also add `python -m venv` in README, and fix the year in the footer.
![image](https://user-images.githubusercontent.com/15976103/92071146-8d760280-ede0-11ea-887c-6b53c57efb58.png)
