### PR TITLE
Disable pylint superfluous-parens only on the false positive line

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -6,7 +6,6 @@ disable=
     broad-except,
     duplicate-code,
     missing-docstring,
-    superfluous-parens,
     too-few-public-methods,
     too-many-arguments,
     too-many-instance-attributes,

--- a/gpxtrackposter/track_loader.py
+++ b/gpxtrackposter/track_loader.py
@@ -138,7 +138,9 @@ class TrackLoader:
             # tricky to pass the timezone
             if str(activity.id) in tracks_names:
                 continue
-            if filter_type and activity.type not in ([filter_type] if isinstance(filter_type, str) else filter_type):
+            if filter_type and activity.type not in (
+                [filter_type] if isinstance(filter_type, str) else filter_type
+            ):  # pylint: disable=superfluous-parens
                 continue
             t = Track()
             t.load_strava(activity)


### PR DESCRIPTION
In #75, pylint `superfluous-parens` was disabled globally because it was complaining false positively.

Better to disable it only on the line where the false positive happens.