### PR TITLE
Rename activity option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ usage: create_poster [-h] [--gpx-dir DIR] [--output FILE]
                      [--activity-type ACTIVITY_TYPE]
                      [--with-animation] [--animation-time ANIMATION_TIME]
                      [--heatmap-center LAT,LNG] [--heatmap-radius RADIUS_KM]
-                     [--circular-rings] [--circular-ring-color COLOR] [--circular-ring-max-distance DISTANCE KM]
+                     [--circular-rings] [--circular-ring-color COLOR]
+                     [--circular-ring-max-distance DISTANCE KM]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -80,7 +81,7 @@ optional arguments:
                         special_color2
   --min-distance DISTANCE
                         min distance by km for track filter
-  --activity-type ACTIVITY_TYPE
+  --activity-type ACTIVITY_TYPE, --activity ACTIVITY_TYPE
                         Filter tracks by activity type; e.g. 'running'
                         (default: all activity types)
   --with-animation      add animation to the poster

--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ usage: create_poster [-h] [--gpx-dir DIR] [--output FILE]
                      [--track-color COLOR] [--track-color2 COLOR]
                      [--text-color COLOR] [--special-color COLOR]
                      [--special-color2 COLOR] [--units UNITS] [--clear-cache]
+                     [--workers NUMBER_OF_WORKERS]
                      [--from-strava FILE] [--verbose] [--logfile FILE]
                      [--special-distance DISTANCE]
                      [--special-distance2 DISTANCE] [--min-distance DISTANCE]
+                     [--activity-type ACTIVITY_TYPE]
+                     [--with-animation] [--animation-time ANIMATION_TIME]
                      [--heatmap-center LAT,LNG] [--heatmap-radius RADIUS_KM]
                      [--circular-rings] [--circular-ring-color COLOR] [--circular-ring-max-distance DISTANCE KM]
 
@@ -40,8 +43,8 @@ optional arguments:
   --output FILE         Name of generated SVG image file (default:
                         "poster.svg").
   --language LANGUAGE   Language (default: english).
-  --localedir DIR       The directory where the translation files can be
-                        found (default: the system's locale directory).
+  --localedir DIR       The directory where the translation files can be found
+                        (default: the system's locale directory).
   --year YEAR           Filter tracks by year; "NUM", "NUM-NUM", "all"
                         (default: all years)
   --title TITLE         Title to display.
@@ -65,7 +68,7 @@ optional arguments:
   --workers NUMBER_OF_WORKERS
                         Number of parallel track loading workers
                         (default: number of CPU cores)
-  --from-strava FILE    JSON file containning config used to get activities
+  --from-strava FILE    JSON file containing config used to get activities
                         from strava
   --verbose             Verbose logging.
   --logfile FILE
@@ -73,12 +76,16 @@ optional arguments:
                         Special Distance1 by km and color with the
                         special_color
   --special-distance2 DISTANCE
-                        Special Distance2 by km and corlor with the
+                        Special Distance2 by km and color with the
                         special_color2
   --min-distance DISTANCE
                         min distance by km for track filter
+  --activity-type ACTIVITY_TYPE
+                        Filter tracks by activity type; e.g. 'running'
+                        (default: all activity types)
   --with-animation      add animation to the poster
-  --animation-time      animation duration (default 30s)
+  --animation-time ANIMATION_TIME
+                        animation duration (default: 30s)
 
 Heatmap Type Options:
   --heatmap-center LAT,LNG

--- a/gpxtrackposter/cli.py
+++ b/gpxtrackposter/cli.py
@@ -194,7 +194,7 @@ def main() -> None:
         help="min distance by km for track filter",
     )
     args_parser.add_argument(
-        "--activity-type",
+        "--activity-type", "--activity",
         dest="activity_type",
         metavar="ACTIVITY_TYPE",
         type=str,

--- a/gpxtrackposter/cli.py
+++ b/gpxtrackposter/cli.py
@@ -194,12 +194,12 @@ def main() -> None:
         help="min distance by km for track filter",
     )
     args_parser.add_argument(
-        "--activity",
-        dest="activity",
-        metavar="ACTIVITY",
+        "--activity-type",
+        dest="activity_type",
+        metavar="ACTIVITY_TYPE",
         type=str,
         default="all",
-        help="Filter tracks by activity; e.g. 'running' (default: all activities)",
+        help="Filter tracks by activity type; e.g. 'running' (default: all activity types)",
     )
     args_parser.add_argument(
         "--with-animation",
@@ -236,7 +236,7 @@ def main() -> None:
 
     loader.special_file_names = args.special
     loader.set_min_length(args.min_distance * Units().km)
-    loader.set_activity(args.activity)
+    loader.set_activity(args.activity_type)
     if args.clear_cache:
         print("Clearing cache...")
         loader.clear_cache()

--- a/gpxtrackposter/cli.py
+++ b/gpxtrackposter/cli.py
@@ -194,7 +194,8 @@ def main() -> None:
         help="min distance by km for track filter",
     )
     args_parser.add_argument(
-        "--activity-type", "--activity",
+        "--activity-type",
+        "--activity",
         dest="activity_type",
         metavar="ACTIVITY_TYPE",
         type=str,

--- a/gpxtrackposter/cli.py
+++ b/gpxtrackposter/cli.py
@@ -205,14 +205,14 @@ def main() -> None:
         "--with-animation",
         dest="with_animation",
         action="store_true",
-        help="If the `poster` contains animation or not",
+        help="add animation to the poster",
     )
     args_parser.add_argument(
         "--animation-time",
         dest="animation_time",
         type=int,
         default=30,
-        help="Animation show time",
+        help="animation duration (default: 30s)",
     )
 
     for _, drawer in drawers.items():


### PR DESCRIPTION
This PR renames the option "activity" to "activity_type" to be more clear and consistent with other options.
Additionally, this PR adds the filter "--activity-type" and other options to the README by running the script update-readme.