### PR TITLE
Quickfix: maximum pint version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/gpxtrackposter/calendar_drawer.py
+++ b/gpxtrackposter/calendar_drawer.py
@@ -105,7 +105,7 @@ class CalendarDrawer(TracksDrawer):
                 text_date = date.strftime("%Y-%m-%d")
                 if text_date in self.poster.tracks_by_date:
                     tracks = self.poster.tracks_by_date[text_date]
-                    length = pint.quantity.Quantity(sum([t.length() for t in tracks]))
+                    length = pint.quantity.Quantity(sum(t.length() for t in tracks))
                     has_special = len([t for t in tracks if t.special]) > 0
                     color = self.color(self.poster.length_range_by_date, length, has_special)
                     g.add(dr.rect(pos, dim, fill=color))

--- a/gpxtrackposter/circular_drawer.py
+++ b/gpxtrackposter/circular_drawer.py
@@ -248,7 +248,7 @@ class CircularDrawer(TracksDrawer):
         values: str = "",
         key_times: str = "",
     ) -> None:
-        length = pint.quantity.Quantity(sum([t.length() for t in tracks]))
+        length = pint.quantity.Quantity(sum(t.length() for t in tracks))
         has_special = len([t for t in tracks if t.special]) > 0
         color = self.color(self.poster.length_range_by_date, length, has_special)
         max_length = self.poster.length_range_by_date.upper()

--- a/gpxtrackposter/github_drawer.py
+++ b/gpxtrackposter/github_drawer.py
@@ -106,7 +106,7 @@ class GithubDrawer(TracksDrawer):
                     date_title = str(github_rect_day)
                     if date_title in self.poster.tracks_by_date:
                         tracks = self.poster.tracks_by_date[date_title]
-                        length = pint.quantity.Quantity(sum([t.length() for t in tracks]))
+                        length = pint.quantity.Quantity(sum(t.length() for t in tracks))
                         distance1 = self.poster.special_distance["special_distance"]
                         distance2 = self.poster.special_distance["special_distance2"]
                         has_special = distance1 < length < distance2

--- a/gpxtrackposter/poster.py
+++ b/gpxtrackposter/poster.py
@@ -155,7 +155,7 @@ class Poster:
             self.tracks_by_date[text_date].append(track)
             self.length_range.extend(track.length())
         for date_tracks in self.tracks_by_date.values():
-            length = pint.quantity.Quantity(sum([t.length() for t in date_tracks]))
+            length = pint.quantity.Quantity(sum(t.length() for t in date_tracks))
             self.length_range_by_date.extend(length)
 
     def draw(self, drawer: "TracksDrawer", output: str) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ appdirs>=1.4.0
 colour
 geopy
 gpxpy>=1.1.2
-pint
+pint<0.20
 pytz
 s2sphere
 svgwrite>=1.1.9

--- a/tests/test_track_loader.py
+++ b/tests/test_track_loader.py
@@ -37,7 +37,7 @@ def fixture_mock_hike_activity(mocker: MockerFixture) -> MagicMock:
     return mock_activity(mocker, "Hike")
 
 
-def strava_config(tmp_path: Path, activity_type: Union[str, List[str]] = None) -> str:
+def strava_config(tmp_path: Path, activity_type: Union[str, List[str], None] = None) -> str:
     config: Dict[str, Union[str, List[str]]] = {
         "client_id": "YOUR STRAVA API CLIENT ID",
         "client_secret": "YOUR STRAVA API CLIENT SECRET",


### PR DESCRIPTION
This PR addresses the issue that the pint library has changed by fixing the maximum pint version to 0.19.
This is considered as a quickfix without major changes in the codebase.
Fixes pylint and mypy issues raised because of changes in their defaults.
Fixes issue #106 