### PR TITLE
Move setup instruction to top and improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,27 @@ WORKDIR /usr/src/app
 COPY requirements.txt ./
 COPY ./ /usr/src/app/
 
-RUN pip install --upgrade pip wheel && \
-    pip install --upgrade -r requirements.txt && \
+RUN pip install --no-cache-dir --upgrade pip wheel && \
+    pip install --no-cache-dir --upgrade -r requirements.txt && \
     pip install .
 
 RUN \
+    rm -rf /usr/share/man/* && \
+    rm -rf /root/.cache/pip/ && \
     rm -rf /usr/src/app/.git* && \
     rm -rf /usr/src/app/examples && \
     rm -rf /usr/src/app/venv
 
 RUN apt-get purge -y \
         make \
-        gcc &&\
+        git \
+        wget \
+        unzip \
+        perl \
+        gcc && \
     apt-get autoremove -y && \
     apt-get autoclean -y && \
     apt-get clean all
+
+
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,20 @@ FROM python:3
 
 WORKDIR /usr/src/app
 COPY requirements.txt ./
-COPY src ./src
-COPY create_poster.py ./
-RUN pip install --no-cache-dir -r requirements.txt
+COPY ./ /usr/src/app/
+
+RUN pip install --upgrade pip wheel && \
+    pip install --upgrade -r requirements.txt && \
+    pip install .
+
+RUN \
+    rm -rf /usr/src/app/.git* && \
+    rm -rf /usr/src/app/examples && \
+    rm -rf /usr/src/app/venv
+
+RUN apt-get purge -y \
+        make \
+        gcc &&\
+    apt-get autoremove -y && \
+    apt-get autoclean -y && \
+    apt-get clean all

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Create a visually appealing poster from your GPX tracks - heavily inspired by ht
 7. Run `create_poster` (see above)
 8. Deactivate virtualenv: `deactivate`
 
+### Container
+There is a Dockerfile in this repository, which you can use to run this software.
+1. Build the container: `podman build -f Dockerfile -t gpxtrackposter:latest`
+2. Run the container to build your poster: `podman run --rm -v /my/gpx/files:/gpx --name gpxtrackposter localhost/gpxtrackposter:latest  create_poster --gpx-dir /gpx --output /gpx/poster.svg`
+
 ## Usage
 First of all, you need directory with a bunch of GPX files (e.g. you can export all your tracks from Garmin Connect with the excellent tool [garmin-connect-export](https://github.com/kjkjava/garmin-connect-export), or use [StravaExportToGPX](https://github.com/flopp/StravaExportToGPX), or use [runtastic](https://github.com/yihong0618/Runtastic), or use [nrc-exporter](https://github.com/yasoob/nrc-exporter) to convert the activities in a Strava or Runtastic or `Nike Run Club` export zip file to GPX or GPX files).
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@
 # GpxTrackPoster
 Create a visually appealing poster from your GPX tracks - heavily inspired by https://www.instagram.com/p/Behppx9HCfx/
 
+## Setup
+1. Clone the repository: `git clone https://github.com/flopp/GpxTrackPoster.git`
+2. `cd GpxTrackPoster`
+3. Create virtualenv: `virtualenv -p /usr/bin/python3 venv` or `python -m venv venv`
+4. Activate virtualenv: `source venv/bin/activate`
+5. Install the package: `pip install .`
+6. Install development requirements (only if you want to contribute code!): `pip install -r requirements-dev.txt`
+7. Run `create_poster` (see above)
+8. Deactivate virtualenv: `deactivate`
 
 ## Usage
 First of all, you need directory with a bunch of GPX files (e.g. you can export all your tracks from Garmin Connect with the excellent tool [garmin-connect-export](https://github.com/kjkjava/garmin-connect-export), or use [StravaExportToGPX](https://github.com/flopp/StravaExportToGPX), or use [runtastic](https://github.com/yihong0618/Runtastic), or use [nrc-exporter](https://github.com/yasoob/nrc-exporter) to convert the activities in a Strava or Runtastic or `Nike Run Club` export zip file to GPX or GPX files).
@@ -212,17 +221,6 @@ We currently support
 - Chinese (`--language zh_CN`)
 - Russian (`--language ru_RU`)
 - Finnish (`--language fi_FI`)
-
-
-## Setup
-1. Clone the repository: `git clone https://github.com/flopp/GpxTrackPoster.git`
-2. `cd GpxTrackPoster`
-3. Create virtualenv: `virtualenv -p /usr/bin/python3 venv` or `python -m venv venv`
-4. Activate virtualenv: `source venv/bin/activate`
-5. Install the package: `pip install .`
-6. Install development requirements (only if you want to contribute code!): `pip install -r requirements-dev.txt`
-7. Run `create_poster` (see above)
-8. Deactivate virtualenv: `deactivate`
 
 ## Contributing
 If you have found a bug or have a feature request, please create a new issue. I'm always happy improve the implementation!


### PR DESCRIPTION
It took me an embarrassing amount of time to find the setup instructions.

So I merely propose to put the setup instructions on the top of the README, like most projects do.

Due to my not being too used to GitHub, I accidentally added some changes to the Dockerfile in this PR.

Before cleaning things up, @flopp please do let me know if this is something that you would be interested in. Then I will gladly proceed and work on the container topic and polish it.